### PR TITLE
[amebalite][eco:matter] Matter Secure Support for amebaLite

### DIFF
--- a/amebalite_gcc_project/amebalite_layout.ld
+++ b/amebalite_gcc_project/amebalite_layout.ld
@@ -13,7 +13,11 @@
 /* layout configuration */
 #define TZ_NSC_SIZE 	 			(4)
 #define TZ_ENTRY_SIZE 				(16)
+#if defined(CONFIG_MATTER_SECURE_EN)
+#define TZ_S_SIZE 					(140)
+#else
 #define TZ_S_SIZE 					(44)
+#endif
 
 #if defined(CONFIG_IMG3_SRAM)
 #define RAM_TZ_NSC_SIZE 	 		KBYTES(TZ_NSC_SIZE)

--- a/amebalite_gcc_project/menuconfig/config.in
+++ b/amebalite_gcc_project/menuconfig/config.in
@@ -700,6 +700,12 @@ if [ "$CONFIG_MATTER_EN" = "y" ]; then
 			define_bool CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION y
 		fi
 	fi
+	if [ "$CONFIG_TRUSTZONE_FOR_KM4" = "y" ]; then
+		bool "Enable Matter Secure"					CONFIG_MATTER_SECURE_EN
+		if [ "$CONFIG_MATTER_SECURE_EN" = "y" ]; then
+			define_bool CONFIG_MATTER_SECURE y
+		fi
+	fi
 fi
 endmenu
 

--- a/amebalite_gcc_project/project_km4/asdk/make_secure/Makefile
+++ b/amebalite_gcc_project/project_km4/asdk/make_secure/Makefile
@@ -24,6 +24,9 @@ COMPONENT_CLEAN += mbedtls
 $(foreach n, $(COMPONENT), $(eval $(call GenerateTargets, $(n),all)))
 
 all: $(addsuffix -all, $(COMPONENT))
+ifeq ($(CONFIG_MATTER_SECURE_EN),y)
+	@make -C $(MATTER_BUILDDIR)/make/mbedtls_secure all
+endif
 
 #*****************************************************************************#
 #              CLEAN GENERATED FILES                                          #
@@ -31,5 +34,8 @@ all: $(addsuffix -all, $(COMPONENT))
 $(foreach n, $(COMPONENT_CLEAN), $(eval $(call GenerateTargets,$(n),clean)))
 
 clean: $(addsuffix -clean, $(COMPONENT_CLEAN))
+ifeq ($(CONFIG_MATTER_SECURE_EN),y)
+	@make -C $(MATTER_BUILDDIR)/make/mbedtls_secure clean
+endif
 
 -include $(DEPS)

--- a/amebalite_gcc_project/project_km4/inc/FreeRTOSConfig.h
+++ b/amebalite_gcc_project/project_km4/inc/FreeRTOSConfig.h
@@ -86,7 +86,11 @@ extern uint32_t SystemCoreClock;
 #define configMINIMAL_SECURE_STACK_SIZE					( 1024 )
 #define configMAX_TASK_NAME_LEN							( 24 )
 
+#if defined(CONFIG_MATTER_SECURE) && CONFIG_MATTER_SECURE
+#define secureconfigTOTAL_SRAM_HEAP_SIZE			( ( ( size_t ) ( 20 * 1024 ) ) )
+#else
 #define secureconfigTOTAL_SRAM_HEAP_SIZE			( ( ( size_t ) ( 6 * 1024 ) ) )
+#endif
 #define secureconfigTOTAL_PSRAM_HEAP_SIZE			( ( ( size_t ) ( 128 * 1024 ) ) )
 
 /* Constants that build features in or out. */


### PR DESCRIPTION
* Increase TZ_S_SIZE to 140 KB if CONFIG_MATTER_SECURE_EN is enabled
* Add Config Matter Secure at make menuconfig
* Compile secure MbedTLS at make_secure
* Increase secureconfigTOTAL_SRAM_HEAP_SIZE size to 20 * 1024 if CONFIG_MATTER_SECURE_EN is enabled