### PR TITLE
[amebasmart][eco:matter] Matter Secure Support for AmebaSmart

### DIFF
--- a/amebasmart_gcc_project/menuconfig/config.in
+++ b/amebasmart_gcc_project/menuconfig/config.in
@@ -1150,6 +1150,10 @@ if [ "$CONFIG_MATTER_EN" = "y" ]; then
 			define_bool CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION y
 		fi
 	fi
+	bool "Enable Matter Secure"					CONFIG_MATTER_SECURE_EN
+	if [ "$CONFIG_MATTER_SECURE_EN" = "y" ]; then
+		define_bool CONFIG_MATTER_SECURE y
+	fi
 fi
 endmenu
 

--- a/component/soc/amebasmart/atf/Makefile
+++ b/component/soc/amebasmart/atf/Makefile
@@ -16,6 +16,30 @@ COMPILEOS = $(shell uname -o)
 LINUX_OS = GNU/Linux
 PROJECT_DIR = ../../../../amebasmart_gcc_project/project_ap
 
+ifeq ($(CONFIG_MATTER_SECURE_EN),y)
+BASEDIR           = ../../../..
+MATTER_DIR        = $(BASEDIR)/component/application/matter
+MATTER_BUILDDIR   = $(MATTER_DIR)/project/amebasmart
+MATTER_MBEDTLSDIR = $(MATTER_DIR)/common/mbedtls
+ifeq ($(MBEDTLS_MATTER_ENABLE),y)
+ifeq ($(MATTER_V_1_3_EN),y)
+MBEDTLS_DIR	      = $(MATTER_MBEDTLSDIR)/mbedtls-2.28.1
+else ifeq ($(MATTER_V_1_4_EN),y)
+ifeq ($(MBEDTLS_MATTER_V_2_28_1_ENABLE),y)
+MBEDTLS_DIR	      = $(MATTER_MBEDTLSDIR)/mbedtls-2.28.1
+else ifeq ($(MBEDTLS_MATTER_V_3_6_1_ENABLE),y)
+MBEDTLS_DIR	      = $(MATTER_MBEDTLSDIR)/mbedtls-3.6.1
+endif #MBEDTLS_MATTER_V_X_X_X_ENABLE
+endif #MATTER_V_1_X_EN
+else
+ifeq ($(MBEDTLS_V_2_16_9_ENABLE), y)
+MBEDTLS_DIR	 = $(BASEDIR)/component/ssl/mbedtls-2.16.9
+else ifeq ($(MBEDTLS_V_3_4_1_ENABLE), y)
+MBEDTLS_DIR	 = $(BASEDIR)/component/ssl/mbedtls-3.4.1
+endif #MBEDTLS_V_X_X_X_ENABLE
+endif #MBEDTLS_MATTER_ENABLE
+endif #CONFIG_MATTER_SECURE_EN
+
 ifeq ($(COMPILEOS),$(LINUX_OS))
 CROSS_COMPILE = $(TOOLCHAINDIR)/asdk-$(ASDK_VER)/linux/newlib/bin/arm-none-eabi-
 else
@@ -655,6 +679,14 @@ $(info Including ${AARCH32_SP_MAKE})
 include ${AARCH32_SP_MAKE}
 endif
 
+endif
+
+################################################################################
+# Include Matter Secure
+################################################################################
+
+ifeq ($(CONFIG_MATTER_SECURE_EN),y)
+include $(MATTER_BUILDDIR)/make/atf/Makefile
 endif
 
 ################################################################################

--- a/component/soc/amebasmart/atf/plat/realtek/sheipa/include/rtk_svc_setup.h
+++ b/component/soc/amebasmart/atf/plat/realtek/sheipa/include/rtk_svc_setup.h
@@ -8,5 +8,8 @@
 
 /* SMC function IDs for Standard Service queries */
 #define RTK_SMC_TEST		0x82000001
+#if defined(CONFIG_MATTER_SECURE) && (CONFIG_MATTER_SECURE == 1)
+#include <matter_rtk_svc_setup.h>
+#endif
 
 #endif /* BSEC_SVC_H */

--- a/component/soc/amebasmart/atf/plat/realtek/sheipa/service/rtk_svc_setup.c
+++ b/component/soc/amebasmart/atf/plat/realtek/sheipa/service/rtk_svc_setup.c
@@ -49,6 +49,29 @@ static uintptr_t rtk_smc_handler(uint32_t smc_fid,
 		ret1 = rtk_secure_service(x1, x2, x3, &ret2);
 		ret2_enabled = true;
 		break;
+#if defined(CONFIG_MATTER_SECURE) && (CONFIG_MATTER_SECURE == 1)
+	case MATTER_SECURE_MBEDTLS_INIT:
+		matter_secure_mbedtls_init((uint32_t) x1);
+		break;
+	case MATTER_SECURE_DAC_INIT_KEYPAIR:
+		ret1 = matter_secure_dac_init_keypair((uint8_t *) x1, (size_t) x2);
+		break;
+	case MATTER_SECURE_ECDSA_SIGN_MSG:
+		ret1 = matter_secure_ecdsa_sign_msg((matter_key_type) x1, (const unsigned char *) x2, (size_t) x3, (unsigned char *) x4);
+		break;
+	case MATTER_SECURE_GET_OPKEY:
+		ret1 = matter_secure_get_opkey((uint8_t *) x1, (size_t) x2);
+		break;
+	case MATTER_SECURE_GET_OPKEY_PUB:
+		ret1 = matter_secure_get_opkey_pub((uint8_t *) x1, (size_t) x2);
+		break;
+	case MATTER_SECURE_NEW_CSR:
+		ret1 = matter_secure_new_csr((uint8_t *) x1, (size_t) x2);
+		break;
+	case MATTER_SECURE_SERIALIZE:
+		ret1 = matter_secure_serialize((uint8_t *) x1, (size_t) x2);
+		break;
+#endif
 
 	default:
 		WARN("Unimplemented Standard Service Call: 0x%x \n", smc_fid);


### PR DESCRIPTION
+ Add Config Matter Secure at make menuconfig
+ Compile Matter Secure at atf BL32
+ Modified rtk_svc_setup.h to include matter_rtk_svc_setup.h
+ Modified rtk_svc_setup.c to call Matter Secure functions