### PR TITLE
[wifi][eco:matter] Fix WiFi Concurrent Mode for Matter Support

### DIFF
--- a/component/at_cmd/atcmd_wifi.c
+++ b/component/at_cmd/atcmd_wifi.c
@@ -404,11 +404,6 @@ void at_wlconn(void *arg)
 #endif
 
 end:
-#if defined(CONFIG_MATTER) && CONFIG_MATTER
-	if ((ret == RTW_SUCCESS) && (error_no == 0)) {
-		wifi_indication(WIFI_EVENT_STA_ASSOC, NULL, 0, 0);
-	}
-#endif
 	rtos_mem_free((void *)p_wifi_setting);
 	init_wifi_struct();
 	if (error_no == 0) {

--- a/component/wifi/api/wifi_init.c
+++ b/component/wifi/api/wifi_init.c
@@ -50,12 +50,7 @@ void _init_thread(void *param)
 	HAL_WRITE32(REG_AON_WIFI_IPC, 0, val32);
 
 #if defined(CONFIG_MATTER) && CONFIG_MATTER
-	matter_wifi_on(RTW_MODE_STA);
-
-#if CONFIG_AUTO_RECONNECT
-	//setup reconnection flag
-	matter_set_autoreconnect(1);
-#endif
+	matter_wifi_init();
 #else
 	wifi_on(RTW_MODE_STA);
 
@@ -122,11 +117,7 @@ void _init_thread(void *param)
 	wifi_set_user_config();
 
 #if defined(CONFIG_MATTER) && CONFIG_MATTER
-	matter_wifi_on(RTW_MODE_STA);
-#if CONFIG_AUTO_RECONNECT
-	//setup reconnection flag
-	matter_set_autoreconnect(1);
-#endif
+	matter_wifi_init();
 #else
 	wifi_on(RTW_MODE_STA);
 #if CONFIG_AUTO_RECONNECT

--- a/component/wifi/driver/include/rtw_wifi_defs.h
+++ b/component/wifi/driver/include/rtw_wifi_defs.h
@@ -793,6 +793,8 @@ enum rtw_event_indicate {
 
 	/* matter modifications*/
 #if defined(CONFIG_MATTER) && CONFIG_MATTER
+	WIFI_EVENT_MATTER_STA_CONN,
+	WIFI_EVENT_MATTER_STA_DISCONN,
 	WIFI_EVENT_DHCP6_DONE,
 #endif
 	/* flash event */


### PR DESCRIPTION
* Removed WIFI_EVENT_STA_ASSOC indication from at_wlconn of atcmd_wifi
* Simplifiy WiFi initialization for Matter Support
* Added two more wifi event for Matter Support