### PR TITLE
[amebadplus][amebalite][amebasmart][eco:matter] Fix Secure MbedTLS and BLE Matter

### DIFF
--- a/amebadplus_gcc_project/project_km4/inc/FreeRTOSConfig.h
+++ b/amebadplus_gcc_project/project_km4/inc/FreeRTOSConfig.h
@@ -87,7 +87,7 @@ extern uint32_t SystemCoreClock;
 #define configMAX_TASK_NAME_LEN							( 24 )
 
 #if defined(CONFIG_MATTER_SECURE) && CONFIG_MATTER_SECURE
-#define secureconfigTOTAL_SRAM_HEAP_SIZE			( ( ( size_t ) ( 16 * 1024 ) ) )
+#define secureconfigTOTAL_SRAM_HEAP_SIZE			( ( ( size_t ) ( 18 * 1024 ) ) )
 #else
 #define secureconfigTOTAL_SRAM_HEAP_SIZE			( ( ( size_t ) ( 6 * 1024 ) ) )
 #endif

--- a/amebalite_gcc_project/amebalite_layout.ld
+++ b/amebalite_gcc_project/amebalite_layout.ld
@@ -14,7 +14,7 @@
 #define TZ_NSC_SIZE 	 			(4)
 #define TZ_ENTRY_SIZE 				(16)
 #if defined(CONFIG_MATTER_SECURE_EN)
-#define TZ_S_SIZE 					(96)
+#define TZ_S_SIZE 					(112)
 #else
 #define TZ_S_SIZE 					(44)
 #endif

--- a/amebalite_gcc_project/project_km4/inc/FreeRTOSConfig.h
+++ b/amebalite_gcc_project/project_km4/inc/FreeRTOSConfig.h
@@ -87,7 +87,7 @@ extern uint32_t SystemCoreClock;
 #define configMAX_TASK_NAME_LEN							( 24 )
 
 #if defined(CONFIG_MATTER_SECURE) && CONFIG_MATTER_SECURE
-#define secureconfigTOTAL_SRAM_HEAP_SIZE			( ( ( size_t ) ( 16 * 1024 ) ) )
+#define secureconfigTOTAL_SRAM_HEAP_SIZE			( ( ( size_t ) ( 18 * 1024 ) ) )
 #else
 #define secureconfigTOTAL_SRAM_HEAP_SIZE			( ( ( size_t ) ( 6 * 1024 ) ) )
 #endif

--- a/component/bluetooth/example/ble_matter_adapter_peripheral/ble_matter_adapter_peripheral_main.c
+++ b/component/bluetooth/example/ble_matter_adapter_peripheral/ble_matter_adapter_peripheral_main.c
@@ -3,7 +3,8 @@
  * Copyright(c) 2022, Realtek Semiconductor Corporation. All rights reserved.
  *******************************************************************************
  */
-#if defined(CONFIG_PLATFORM_AMEBADPLUS) || defined(CONFIG_PLATFORM_AMEBASMART) || defined(CONFIG_PLATFORM_AMEBALITE)
+#include <platform_autoconf.h>
+#if defined(CONFIG_AMEBADPLUS) || defined(CONFIG_AMEBASMART) || defined(CONFIG_AMEBALITE)
 /*============================================================================*
  *                              Header
  *============================================================================*/

--- a/component/bluetooth/example/ble_matter_adapter_peripheral/ble_matter_adapter_service.c
+++ b/component/bluetooth/example/ble_matter_adapter_peripheral/ble_matter_adapter_service.c
@@ -3,7 +3,8 @@
  * Copyright(c) 2022, Realtek Semiconductor Corporation. All rights reserved.
  *******************************************************************************
  */
-#if defined(CONFIG_PLATFORM_AMEBADPLUS) || defined(CONFIG_PLATFORM_AMEBASMART) || defined(CONFIG_PLATFORM_AMEBALITE)
+#include <platform_autoconf.h>
+#if defined(CONFIG_AMEBADPLUS) || defined(CONFIG_AMEBASMART) || defined(CONFIG_AMEBALITE)
 #include <stdio.h>
 #include <string.h>
 #include <osif.h>


### PR DESCRIPTION
* Increase secure heap to 18KB for AmebaDplus and AmebaLite to accomodate secure MbedTLS 2.28.1
* Increase TZ_S_SIZE to 112 KB for AmebaLite to accomodate secure MbedTLS 2.28.1
* Update config wrapper and included platform_autoconf.h at the source codes of BLE Matter