### PR TITLE
fix: add mbedtls_ssl_set_hostname for MQTT SNI support

### DIFF
--- a/component/network/mqtt/MQTTClient/MQTTFreertos.c
+++ b/component/network/mqtt/MQTTClient/MQTTFreertos.c
@@ -413,6 +413,8 @@ int NetworkConnect(Network *n, char *addr, int port)
 			mbedtls_ssl_conf_own_cert(n->conf, client_crt, client_rsa);
 		}
 
+		mbedtls_ssl_set_hostname(n->ssl, addr);
+
 		retVal = mbedtls_ssl_handshake(n->ssl);
 		if (retVal < 0) {
 			mqtt_printf(MQTT_DEBUG, "ssl handshake failed err:-0x%04X", -retVal);


### PR DESCRIPTION
## Problem
  MQTT over SSL/TLS connection fails because the server receives no SNI (Server Name Indication), causing the server to reject the connection.

  ## Fix
  Add `mbedtls_ssl_set_hostname(n->ssl, addr)` before `mbedtls_ssl_handshake()` in `NetworkConnect()` so that the SNI extension is sent during the TLS handshake.

  ## Changes
  - File: `component/network/mqtt/MQTTClient/MQTTFreertos.c`
  - Diff: +2 lines (1 line of code + 1 blank line)
  - Clean minimal change, no formatting modifications

## Fixed: Master（v1.3）branch