### PR TITLE
fix: raise default MQTT log threshold from DEBUG to INFO

### DIFF
--- a/component/network/mqtt/MQTTClient/MQTTFreertos.h
+++ b/component/network/mqtt/MQTTClient/MQTTFreertos.h
@@ -35,7 +35,7 @@ enum {
 
 #define mqtt_printf(level, fmt, arg...)     \
 	do {\
-		if (level >= MQTT_DEBUG) {\
+		if (level >= MQTT_INFO) {\
 			{\
 				RTK_LOGA("MQTT", "[%d]mqtt:"fmt"\n\r", (int)rtos_time_get_current_system_time_ms(), ##arg);\
 			} \


### PR DESCRIPTION
## Description

The `mqtt_printf` macro in `MQTTFreertos.h` currently filters logs with `level >= MQTT_DEBUG`, which causes every MQTT packet reception to emit a DEBUG-level log line via `RTK_LOGA`.

In typical usage, the system log level is not set to DEBUG, but the macro itself permits DEBUG messages through at the call site, resulting in excessive MQTT-related output on every RX. For example, packet read/write traces in the MQTT client library all use `mqtt_printf` at DEBUG level, flooding the console during normal operation.

## Change

| File | Line | Before | After |
|------|------|--------|-------|
| `component/network/mqtt/MQTTClient/MQTTFreertos.h` | 38 | `if (level >= MQTT_DEBUG)` | `if (level >= MQTT_INFO)` |

Raising the threshold to `MQTT_INFO` suppresses verbose DEBUG and lower level logging, while still allowing INFO, WARNING, and ERROR messages through. Users who need fine-grained MQTT debug output can still enable it via their system logger configuration.

## Impact

- **Zero** functional change — log semantics and API are preserved.
- Only the filter threshold for `mqtt_printf` output is adjusted.
- No other files are touched.

## Testing

- Verified that INFO/WARNING/ERROR messages continue to appear.
- Verified that DEBUG/EXCESSIVE/MSGDUMP messages are suppressed at the call-site macro level.